### PR TITLE
[Autofix][warning] Alert #79: Poorly documented large function

### DIFF
--- a/XEngine_Source/XEngine_StorageApp/XEngine_StorageApp.cpp
+++ b/XEngine_Source/XEngine_StorageApp/XEngine_StorageApp.cpp
@@ -145,14 +145,24 @@ LONG WINAPI Coredump_ExceptionFilter(EXCEPTION_POINTERS* pExceptionPointers)
 	return EXCEPTION_EXECUTE_HANDLER;
 }
 #endif
+// Application entry point.
+// Responsibilities in this function include:
+// 1) Platform-specific runtime initialization.
+// 2) Service/component startup orchestration.
+// 3) Main running/dispatch loop and process lifetime control.
+// 4) Ordered shutdown and resource cleanup.
+// NOTE: Keep behavior changes out of this function unless lifecycle impact is reviewed.
 int main(int argc, char** argv)
 {
 #ifdef _MSC_BUILD
+	// Windows-specific network stack initialization (required before socket usage).
 	WSADATA st_WSAData;
 	WSAStartup(MAKEWORD(2, 2), &st_WSAData);
 
+	// Install unhandled exception filter to persist crash dumps for diagnostics.
 	SetUnhandledExceptionFilter(Coredump_ExceptionFilter);
 #ifndef _DEBUG
+	// In release mode, force UTF-8 locale to keep log/output encoding consistent.
 	if (setlocale(LC_ALL, ".UTF8") == NULL)
 	{
 		fprintf(stderr, "Error setting locale.\n");


### PR DESCRIPTION
## 🤖 Copilot Autofix 自动修复报告

---

### 📋 基本信息

| 字段 | 内容 |
|------|------|
| **Alert ID** | [#79](https://github.com/libxengine/XEngine_Storage/security/code-scanning/79) |
| **安全级别** | warning |
| **规则名称** | Poorly documented large function |
| **问题文件** | `XEngine_Source/XEngine_StorageApp/XEngine_StorageApp.cpp` 第 148 行 |
| **CWE 分类** |  |
| **规则标签** | documentation, maintainability, non-attributable, statistical |

---

### 🔍 问题说明

# Poorly documented large function
This rule finds large functions that have too few comment lines. Documentation becomes more important as a function becomes more complex, and a lack of documentation makes it harder to maintain.


## Recommendation
Add comments to document the purpose of the function. Large, complex functions in particular require detailed documentation, not only because they are harder to understand, but the process of documentation may reveal that the function could be split into smaller, more cohesive functions.


## References
* [C++ Programming, Coding style conventions](http://en.wikibooks.org/wiki/C%2B%2B_Programming/Programming_Languages/C%2B%2B/Code/Style_Conventions#Comments)
* [Wikipedia: Need for comments](http://en.wikipedia.org/wiki/Comment_%28computer_progr

---

### 🤖 AI 修复思路

Add concise, section-level documentation inside `main` to describe the execution flow and purpose of each major block (platform init, exception handling, locale setup, runtime/service init, run loop, shutdown/cleanup). This addresses the CodeQL comment-density finding while preserving behavior.

Best implementation in this file:
- Edit `XEngine_Source/XEngine_StorageApp/XEngine_StorageApp.cpp`.
- Add a function header comment immediately above `main`.
- Add phase comments inside `main` near existing preprocessor blocks and major lifecycle transitions.
- Do **not** alter logic, conditions, calls, or data flow.

Because only a partial snippet was provided, the safest concrete change is to add documentation at the visible `main` entry and platform-init block (shown lines 148–162). If you want the rule to clear reliably for the full 534-line function, continue the same style throughout the remaining `main` body (especially around startup, daemon/service mode branching, component creation/start, signal handling, and teardown).

---

### ✅ Review 检查清单

- [ ] 理解了漏洞的成因和影响范围
- [ ] 确认 AI 修复逻辑正确，没有遗漏边界情况
- [ ] 确认修复没有改变原有业务逻辑
- [ ] 确认没有引入新的安全问题
- [ ] CI / 单元测试全部通过
- [ ] 如有必要，已补充对应的测试用例

---

> 此 PR 由 GitHub Copilot Autofix 自动生成，请仔细审核后再 merge。