### PR TITLE
[Autofix][warning] Alert #75: Poorly documented large function

### DIFF
--- a/XEngine_Source/StorageModule_Config/Config_Json/Config_Json.cpp
+++ b/XEngine_Source/StorageModule_Config/Config_Json/Config_Json.cpp
@@ -42,18 +42,23 @@ CConfig_Json::~CConfig_Json()
 *********************************************************************/
 bool CConfig_Json::Config_Json_File(LPCXSTR lpszConfigFile, XENGINE_SERVERCONFIG* pSt_ServerConfig)
 {
+	// 初始化错误状态；函数开始默认“无错误”，出现任何失败分支时再设置错误码并返回。
 	Config_IsErrorOccur = false;
 
+	// 参数有效性检查：配置文件路径与输出结构体指针都不允许为空。
 	if ((NULL == lpszConfigFile) || (NULL == pSt_ServerConfig))
 	{
 		Config_IsErrorOccur = true;
 		Config_dwErrorCode = ERROR_XENGINE_BLOGIC_CONFIG_JSON_PARAMENT;
 		return false;
 	}
+
+	// JSON 解析相关对象：错误信息、根节点、Reader 构造器。
 	JSONCPP_STRING st_JsonError;
 	Json::Value st_JsonRoot;
 	Json::CharReaderBuilder st_JsonBuilder;
 
+	// 以二进制只读方式打开配置文件；打开失败视为参数/路径错误。
 	FILE* pSt_File = _xtfopen(lpszConfigFile, _X("rb"));
 	if (NULL == pSt_File)
 	{
@@ -61,10 +66,13 @@ bool CConfig_Json::Config_Json_File(LPCXSTR lpszConfigFile, XENGINE_SERVERCONFIG
 		Config_dwErrorCode = ERROR_XENGINE_BLOGIC_CONFIG_JSON_PARAMENT;
 		return false;
 	}
+
+	// 读取文件内容到固定缓冲区，并在读取后立即关闭文件句柄。
 	XCHAR tszMsgBuffer[8192] = {};
 	size_t nRet = fread(tszMsgBuffer, 1, sizeof(tszMsgBuffer), pSt_File);
 	fclose(pSt_File);
 
+	// 执行 JSON 反序列化；解析失败时设置解析错误码并返回。
 	std::unique_ptr<Json::CharReader> const pSt_JsonReader(st_JsonBuilder.newCharReader());
 	if (!pSt_JsonReader->parse(tszMsgBuffer, tszMsgBuffer + nRet, &st_JsonRoot, &st_JsonError))
 	{
@@ -72,6 +80,8 @@ bool CConfig_Json::Config_Json_File(LPCXSTR lpszConfigFile, XENGINE_SERVERCONFIG
 		Config_dwErrorCode = ERROR_XENGINE_BLOGIC_CONFIG_JSON_PARSE;
 		return false;
 	}
+
+	// 将 JSON 节点字段映射到服务配置结构体。
 	_tcsxcpy(pSt_ServerConfig->tszIPAddr, st_JsonRoot["tszIPAddr"].asCString());
 	pSt_ServerConfig->bDeamon = st_JsonRoot["bDeamon"].asInt();
 	pSt_ServerConfig->nCenterPort = st_JsonRoot["nCenterPort"].asInt();


### PR DESCRIPTION
## 🤖 Copilot Autofix 自动修复报告

---

### 📋 基本信息

| 字段 | 内容 |
|------|------|
| **Alert ID** | [#75](https://github.com/libxengine/XEngine_Storage/security/code-scanning/75) |
| **安全级别** | warning |
| **规则名称** | Poorly documented large function |
| **问题文件** | `XEngine_Source/StorageModule_Config/Config_Json/Config_Json.cpp` 第 43 行 |
| **CWE 分类** |  |
| **规则标签** | documentation, maintainability, non-attributable, statistical |

---

### 🔍 问题说明

# Poorly documented large function
This rule finds large functions that have too few comment lines. Documentation becomes more important as a function becomes more complex, and a lack of documentation makes it harder to maintain.


## Recommendation
Add comments to document the purpose of the function. Large, complex functions in particular require detailed documentation, not only because they are harder to understand, but the process of documentation may reveal that the function could be split into smaller, more cohesive functions.


## References
* [C++ Programming, Coding style conventions](http://en.wikibooks.org/wiki/C%2B%2B_Programming/Programming_Languages/C%2B%2B/Code/Style_Conventions#Comments)
* [Wikipedia: Need for comments](http://en.wikipedia.org/wiki/Comment_%28computer_progr

---

### 🤖 AI 修复思路

The best fix is to add concise, structured inline comments that document each major stage of `CConfig_Json::Config_Json_File` (input validation, file open/read, JSON parser creation/parse, config field extraction, and error reporting/return behavior), while preserving all logic exactly as-is.

For the shown region in `XEngine_Source/StorageModule_Config/Config_Json/Config_Json.cpp`, add section comments immediately above the existing code blocks starting at the function body (line 45 onward). This improves the documentation density and clarifies intent without changing functionality, signatures, or dependencies. No new methods/imports/definitions are required.

---

### ✅ Review 检查清单

- [ ] 理解了漏洞的成因和影响范围
- [ ] 确认 AI 修复逻辑正确，没有遗漏边界情况
- [ ] 确认修复没有改变原有业务逻辑
- [ ] 确认没有引入新的安全问题
- [ ] CI / 单元测试全部通过
- [ ] 如有必要，已补充对应的测试用例

---

> 此 PR 由 GitHub Copilot Autofix 自动生成，请仔细审核后再 merge。