### PR TITLE
[Autofix][high] Alert #74: File created without restricting permissions

### DIFF
--- a/XEngine_Source/XEngine_StorageApp/StorageApp_UPLoader.cpp
+++ b/XEngine_Source/XEngine_StorageApp/StorageApp_UPLoader.cpp
@@ -1,4 +1,8 @@
 ﻿#include "StorageApp_Hdr.h"
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <stdio.h>
 
 XHTHREAD XCALLBACK XEngine_UPLoader_HTTPThread(XPVOID lParam)
 {
@@ -192,9 +196,20 @@ bool XEngine_Task_HttpUPLoader(LPCXSTR lpszClientAddr, LPCXSTR lpszMsgBuffer, in
 					return true;
 				}
 				//文件是否可写
-				FILE* pSt_File = _xtfopen(tszFileDir, _X("wb"));
+				int nFileFD = open(tszFileDir, O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR);
+				if (nFileFD < 0)
+				{
+					st_HDRParam.bIsClose = true;
+					st_HDRParam.nHttpCode = 403;
+					HttpProtocol_Server_SendMsgEx(xhUPHttp, tszSDBuffer, &nSDLen, &st_HDRParam);
+					XEngine_Net_SendMsg(lpszClientAddr, tszSDBuffer, nSDLen, nNetType);
+					XLOG_PRINT(xhLog, XENGINE_HELPCOMPONENTS_XLOG_IN_LOGLEVEL_ERROR, _X("上传客户端:%s,准备上传文件:%s 失败,创建文件失败"), lpszClientAddr, tszFileDir);
+					return true;
+				}
+				FILE* pSt_File = fdopen(nFileFD, "wb");
 				if (NULL == pSt_File)
 				{
+					close(nFileFD);
 					st_HDRParam.bIsClose = true;
 					st_HDRParam.nHttpCode = 403;
 					HttpProtocol_Server_SendMsgEx(xhUPHttp, tszSDBuffer, &nSDLen, &st_HDRParam);


### PR DESCRIPTION
## 🤖 Copilot Autofix 自动修复报告

---

### 📋 基本信息

| 字段 | 内容 |
|------|------|
| **Alert ID** | [#74](https://github.com/libxengine/XEngine_Storage/security/code-scanning/74) |
| **安全级别** | high |
| **规则名称** | File created without restricting permissions |
| **问题文件** | `XEngine_Source/XEngine_StorageApp/StorageApp_UPLoader.cpp` 第 195 行 |
| **CWE 分类** | external/cwe/cwe-732 |
| **规则标签** | external/cwe/cwe-732, security |

---

### 🔍 问题说明

# File created without restricting permissions
When you create a file, take care to give it the most restrictive permissions possible. A typical mistake is to create the file with world-writable permissions. This can allow an attacker to write to the file, which can give them unexpected control over the program.


## Recommendation
Files should usually be created with write permissions only for the current user. If broader permissions are needed, including the users' group should be sufficient. It is very rare that a file needs to be world-writable, and care should be taken not to make assumptions about the contents of any such file.

On Unix systems, it is possible for the user who runs the program to restrict file creation permissions using `umask`. However, a program should not assume t

---

### 🤖 AI 修复思路

General fix approach: avoid `fopen("wb")` for security-sensitive file creation when you need strict permissions. Instead, create the file descriptor with explicit mode bits (`0600`, i.e., user read/write only) using `open(..., O_CREAT, S_IRUSR | S_IWUSR)`, then wrap it with `fdopen` if a `FILE*` is needed.

Best fix in this snippet (without changing functionality): replace the `_xtfopen(..., "wb")` probe-create block at lines 195–205 with a POSIX-style `open` using explicit restrictive permissions and then `fdopen` for compatibility with existing `FILE*` handling. Keep the same error handling behavior and logging. This change is localized to `XEngine_Source/XEngine_StorageApp/StorageApp_UPLoader.cpp` around the “文件是否可写” block.

What is needed:
- Add standard headers for `open`, flags, and `fdopen`/`close`:
  - `<fcntl.h>`
  - `<unistd.h>`
  - `<sys/stat.h>`
  - `<stdio.h>`

---

### ✅ Review 检查清单

- [ ] 理解了漏洞的成因和影响范围
- [ ] 确认 AI 修复逻辑正确，没有遗漏边界情况
- [ ] 确认修复没有改变原有业务逻辑
- [ ] 确认没有引入新的安全问题
- [ ] CI / 单元测试全部通过
- [ ] 如有必要，已补充对应的测试用例

---

> 此 PR 由 GitHub Copilot Autofix 自动生成，请仔细审核后再 merge。