### PR TITLE
[Autofix][high] Alert #71: Incorrect allocation-error handling

### DIFF
--- a/XEngine_Source/StorageModule_BTorrent/BTorrent_Creator/BTorrent_Creator.cpp
+++ b/XEngine_Source/StorageModule_BTorrent/BTorrent_Creator/BTorrent_Creator.cpp
@@ -1,5 +1,6 @@
 ﻿#include "pch.h"
 #include "BTorrent_Creator.h"
+#include <new>
 /********************************************************************
 //    Created:     2023/02/02  16:26:25
 //    File Name:   D:\XEngine\XEngine_SourceCode\XEngine_NetHelp\NetHelp_BTorrent\BTorrent_Creator\BTorrent_Creator.cpp
@@ -49,7 +50,7 @@ XHANDLE CBTorrent_Creator::BTorrent_Creator_Init(LPCXSTR lpszBTPath, int nPieceS
         return NULL;
     }
 	//申请空间
-	BTORRENT_CREATORINFO* pSt_BTCreator = new BTORRENT_CREATORINFO;
+	BTORRENT_CREATORINFO* pSt_BTCreator = new(std::nothrow) BTORRENT_CREATORINFO;
 	if (NULL == pSt_BTCreator)
 	{
 		BTDload_IsErrorOccur = true;
@@ -58,9 +59,9 @@ XHANDLE CBTorrent_Creator::BTorrent_Creator_Init(LPCXSTR lpszBTPath, int nPieceS
 	}
 	*pSt_BTCreator = {};
 	//申请内存
-	pSt_BTCreator->pStl_ListNode = new list<BTORRENT_PARSEMAP>;
-	pSt_BTCreator->pStl_ListSeeds = new list<BTORRENT_PARSEMAP>;
-	pSt_BTCreator->pStl_ListTracker = new list<BTORRENT_PARSEMAP>;
+	pSt_BTCreator->pStl_ListNode = new(std::nothrow) list<BTORRENT_PARSEMAP>;
+	pSt_BTCreator->pStl_ListSeeds = new(std::nothrow) list<BTORRENT_PARSEMAP>;
+	pSt_BTCreator->pStl_ListTracker = new(std::nothrow) list<BTORRENT_PARSEMAP>;
 	if ((NULL == pSt_BTCreator->pStl_ListNode) || (NULL == pSt_BTCreator->pStl_ListSeeds) || (NULL == pSt_BTCreator->pStl_ListTracker))
 	{
 		BTDload_IsErrorOccur = true;


### PR DESCRIPTION
## 🤖 Copilot Autofix 自动修复报告

---

### 📋 基本信息

| 字段 | 内容 |
|------|------|
| **Alert ID** | [#71](https://github.com/libxengine/XEngine_Storage/security/code-scanning/71) |
| **安全级别** | high |
| **规则名称** | Incorrect allocation-error handling |
| **问题文件** | `XEngine_Source/StorageModule_BTorrent/BTorrent_Creator/BTorrent_Creator.cpp` 第 63 行 |
| **CWE 分类** | external/cwe/cwe-252, external/cwe/cwe-570, external/cwe/cwe-755 |
| **规则标签** | correctness, external/cwe/cwe-252, external/cwe/cwe-570, external/cwe/cwe-755, security |

---

### 🔍 问题说明

# Incorrect allocation-error handling
Different overloads of the `new` operator handle allocation failures in different ways. If `new T` fails for some type `T`, it throws a `std::bad_alloc` exception, but `new(std::nothrow) T` returns a null pointer. If the programmer does not use the corresponding method of error handling, allocation failure may go unhandled and could cause the program to behave in unexpected ways.


## Recommendation
Make sure that exceptions are handled appropriately if `new T` is used. On the other hand, make sure to handle the possibility of null pointers if `new(std::nothrow) T` is used.


## Example

```cpp
// BAD: the allocation will throw an unhandled exception
// instead of returning a null pointer.
void bad1(std::size_t length) noexcept {
 int* dest = new int[l

---

### 🤖 AI 修复思路

Use one consistent strategy: either (a) keep plain `new` and catch exceptions, or (b) switch to `new(std::nothrow)` and keep null checks.  
To minimize behavioral change and preserve the existing error-code path, the best fix here is to switch these allocations to `new(std::nothrow)` so the existing `NULL` checks remain valid.

In `XEngine_Source/StorageModule_BTorrent/BTorrent_Creator/BTorrent_Creator.cpp`, inside `BTorrent_Creator_Init`, change:
- `new BTORRENT_CREATORINFO` → `new(std::nothrow) BTORRENT_CREATORINFO`
- all three `new list<BTORRENT_PARSEMAP>` → `new(std::nothrow) list<BTORRENT_PARSEMAP>`

Also add `#include <new>` near the includes so `std::nothrow` is available.

---

### ✅ Review 检查清单

- [ ] 理解了漏洞的成因和影响范围
- [ ] 确认 AI 修复逻辑正确，没有遗漏边界情况
- [ ] 确认修复没有改变原有业务逻辑
- [ ] 确认没有引入新的安全问题
- [ ] CI / 单元测试全部通过
- [ ] 如有必要，已补充对应的测试用例

---

> 此 PR 由 GitHub Copilot Autofix 自动生成，请仔细审核后再 merge。