### PR TITLE
[Autofix][high] Alert #2: Time-of-check time-of-use filesystem race condition

### DIFF
--- a/XEngine_Source/StorageModule_Session/Session_Stroage/Session_DLStroage.cpp
+++ b/XEngine_Source/StorageModule_Session/Session_Stroage/Session_DLStroage.cpp
@@ -142,9 +142,19 @@ bool CSession_DLStroage::Session_DLStroage_Insert(LPCXSTR lpszClientAddr, LPCXST
 	struct _xtstat st_FStat;
 
 	memset(&st_Client, '\0', sizeof(SESSION_STORAGEINFO));
-	int nRet = _xtstat(lpszFileDir, &st_FStat);
+	//先打开文件，再基于已打开句柄获取文件属性，避免TOCTOU
+	st_Client.pSt_File = _xtfopen(lpszFileDir, _X("rb"));
+	if (NULL == st_Client.pSt_File)
+	{
+		Session_IsErrorOccur = true;
+		Session_dwErrorCode = ERROR_STORAGE_MODULE_SESSION_OPENFILE;
+		return false;
+	}
+	int nRet = _xtfstat(_xtfileno(st_Client.pSt_File), &st_FStat);
 	if (-1 == nRet)
 	{
+		xtfclose(st_Client.pSt_File);
+		st_Client.pSt_File = NULL;
 		Session_IsErrorOccur = true;
 		Session_dwErrorCode = ERROR_STORAGE_MODULE_SESSION_OPENFILE;
 		return false;
@@ -166,13 +176,6 @@ bool CSession_DLStroage::Session_DLStroage_Insert(LPCXSTR lpszClientAddr, LPCXST
 		st_Client.xhToken = xhToken;
 	}
 	//填充下载信息
-	st_Client.pSt_File = _xtfopen(lpszFileDir, _X("rb"));
-	if (NULL == st_Client.pSt_File)
-	{
-		Session_IsErrorOccur = true;
-		Session_dwErrorCode = ERROR_STORAGE_MODULE_SESSION_OPENFILE;
-		return false;
-	}
 	//是否有范围
 	if ((nPosStart > 0) || (nPostEnd > 0))
 	{


### PR DESCRIPTION
## 🤖 Copilot Autofix 自动修复报告

---

### 📋 基本信息

| 字段 | 内容 |
|------|------|
| **Alert ID** | [#2](https://github.com/libxengine/XEngine_Storage/security/code-scanning/2) |
| **安全级别** | high |
| **规则名称** | Time-of-check time-of-use filesystem race condition |
| **问题文件** | `XEngine_Source/StorageModule_Session/Session_Stroage/Session_DLStroage.cpp` 第 169 行 |
| **CWE 分类** | external/cwe/cwe-367 |
| **规则标签** | external/cwe/cwe-367, security |

---

### 🔍 问题说明

# Time-of-check time-of-use filesystem race condition
Often it is necessary to check the state of a file before using it. These checks usually take a file name to be checked, and if the check returns positively, then the file is opened or otherwise operated upon.

However, in the time between the check and the operation, the underlying file referenced by the file name could be changed by an attacker, causing unexpected behavior.


## Recommendation
Wherever possible, use functions that operate on file descriptors rather than file names (for example, `fchmod` rather than `chmod`).

For access checks, you can temporarily change the UID and GID to that of the user whose permissions are being checked, and then perform the operation. This has the effect of "atomically" combining a permissions c

---

### 🤖 AI 修复思路

通用修复思路：避免“先按路径检查、再按路径使用”。应先打开文件，再基于**已打开句柄/描述符**获取属性（如大小），确保属性与后续读操作针对同一对象。

本例最佳修复（不改变现有功能）是在 `Session_DLStroage.cpp` 中把 `_xtstat(lpszFileDir, &st_FStat)` 移除为“先 `_xtfopen`，再 `_xtfstat(_xtfileno(...), &st_FStat)`”。这样 `st_Client.ullCount` 来自已打开文件，消除 TOCTOU。需要调整 141~175 区域代码顺序：  
1) 保留 `SESSION_STORAGEINFO st_Client` 和 `struct _xtstat st_FStat`。  
2) 先 `_xtfopen`，失败即返回原错误码。  
3) 再对 `st_Client.pSt_File` 对应 fd 调用 `_xtfstat`，失败时关闭文件并返回错误。  
4) 再填充 `ullPosStart/ullPosEnd/ullCount` 等字段。  
不需要新增第三方依赖；所需函数通常由现有平台封装头（`pch.h`）提供。

---

### ✅ Review 检查清单

- [ ] 理解了漏洞的成因和影响范围
- [ ] 确认 AI 修复逻辑正确，没有遗漏边界情况
- [ ] 确认修复没有改变原有业务逻辑
- [ ] 确认没有引入新的安全问题
- [ ] CI / 单元测试全部通过
- [ ] 如有必要，已补充对应的测试用例

---

> 此 PR 由 GitHub Copilot Autofix 自动生成，请仔细审核后再 merge。