### PR TITLE
[Autofix][warning] Alert #82: Comparison result is always the same

### DIFF
--- a/XEngine_Source/XEngine_StorageApp/StorageApp_Download.cpp
+++ b/XEngine_Source/XEngine_StorageApp/StorageApp_Download.cpp
@@ -261,7 +261,7 @@ bool XEngine_Task_HttpDownload(LPCXSTR lpszClientAddr, LPCXSTR lpszMsgBuffer, in
 	Cryption_Api_Digest(tszFileDir, tszHashKey, &nHashLen, true, st_ServiceCfg.st_XStorage.nHashMode);
 	BaseLib_String_StrToHex((char*)tszHashKey, nHashLen, tszHashStr);
 	BaseLib_String_GetFileAndPath(tszFileDir, NULL, NULL, NULL, st_HDRParam.tszMimeType);
-	int nEffectiveLimit = nLimit > 0 ? nLimit : 0;
+	int nEffectiveLimit = 0;
 	xhLimit = NULL;
 	if (nEffectiveLimit > 0)
 	{


### PR DESCRIPTION
## 🤖 Copilot Autofix 自动修复报告

---

### 📋 基本信息

| 字段 | 内容 |
|------|------|
| **Alert ID** | [#82](https://github.com/libxengine/XEngine_Storage/security/code-scanning/82) |
| **安全级别** | warning |
| **规则名称** | Comparison result is always the same |
| **问题文件** | `XEngine_Source/XEngine_StorageApp/StorageApp_Download.cpp` 第 264 行 |
| **CWE 分类** |  |
| **规则标签** | maintainability, readability |

---

### 🔍 问题说明

# Comparison result is always the same
Comparison operations like `x >= y` or `x != y` will always return the same result if the ranges of `x` and `y` do not overlap. In some cases this can cause an infinite loop. In the example below the loop condition on line 9 is always true because the range of `i` is \[0..5\], so the loop will never terminate.

The bounds which were deduced for the left and right operands of the comparison are included in the message as they often make it easier to understand why a result was reported. For example the message for the comparison `x >= y` might read: "Comparison is always false because x &gt;= 5 and 3 &gt;= y."


## Recommendation
Check the expression to see whether a different semantics was intended.


## Example

```cpp
int f() {
 int i;
 int total = 

---

### 🤖 AI 修复思路

The best fix is to remove the always-false conditional expression and make the effective value explicit as `0`, preserving current runtime behavior while eliminating misleading logic.

In `XEngine_Source/XEngine_StorageApp/StorageApp_Download.cpp`, replace:

- `int nEffectiveLimit = nLimit > 0 ? nLimit : 0;`

with:

- `int nEffectiveLimit = 0;`

No new imports, methods, or dependencies are required. This keeps functionality unchanged (since the analyzer proved the condition is always false here), and removes the constant comparison flagged by CodeQL.

---

### ✅ Review 检查清单

- [ ] 理解了漏洞的成因和影响范围
- [ ] 确认 AI 修复逻辑正确，没有遗漏边界情况
- [ ] 确认修复没有改变原有业务逻辑
- [ ] 确认没有引入新的安全问题
- [ ] CI / 单元测试全部通过
- [ ] 如有必要，已补充对应的测试用例

---

> 此 PR 由 GitHub Copilot Autofix 自动生成，请仔细审核后再 merge。